### PR TITLE
For deployment to Cloud Foundry

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,2 @@
+flight-client/node_modules/.cache/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+flight-client/src/config.js
+
 .gradle
 /build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -86,3 +86,30 @@ to let them know that they should change their location to the selected radar:
 ```
 curl -X POST localhost:8080/location/CDG
 ```
+
+### Deploy to Cloud Foundry
+
+Use the `cf` CLI to target your instance of Cloud Foundry.
+
+Open the file called `manifest-vars.yml` and edit the domains as appropriate for your Cloud Foundry foundation. You can run the command `cf domains` to see the domains available to you.
+
+Next, you need to provide flight-client with the correct URL to flight-tracker on Cloud Foundry (otherwise, the URL defaults to `ws://localhost:8080/rsocket`).
+Run the following following script and enter the appropriate URL when prompted. 
+You can copy/paste the sample value provided by the script - just change the domain as necessary.
+```
+$ ./config-client.sh
+```
+
+Build the radar-collector and flight-client apps.
+Please note that even if you built the projects earlier in this exercise, you must re-build flight-client to incorporate the change in the last step.
+```
+./gradlew :radar-collector:build
+./gradlew :flight-tracker:build
+```
+
+Push the apps to Cloud Foundry, providing `manifest-vars.yml` as input:
+```
+cf push --vars-file manifest-vars.yml
+```
+
+The tracker application is available at `http://flight-tracker.<YOUR-DOMAIN>/index.html`

--- a/config-client.sh
+++ b/config-client.sh
@@ -1,0 +1,14 @@
+echo "Enter flight-tracker URL [ws://flight-tracker.apps.clearlake.cf-app.com/rsocket]: "
+read FLIGHT_TRACKER_URL
+FLIGHT_TRACKER_URL=${FLIGHT_TRACKER_URL:-ws://flight-tracker.apps.clearlake.cf-app.com/rsocket}
+
+echo "module.exports = {" > flight-client/src/config.js
+echo "    FLIGHT_TRACKER_URL: '${FLIGHT_TRACKER_URL}'" >> flight-client/src/config.js
+echo "}" >> flight-client/src/config.js
+
+echo "Successfully set flight-client/src/config.js to"
+echo ""
+cat flight-client/src/config.js
+
+echo ""
+echo "Please re-build flight-tracker before deploying."

--- a/flight-client/src/map.js
+++ b/flight-client/src/map.js
@@ -7,6 +7,14 @@ import radarImg from './img/satellite-dish.png';
 import militaryRadarImg from './img/radar.png';
 import {Metadata} from "./metadata";
 
+let FLIGHT_TRACKER_URL = 'ws://localhost:8080/rsocket';
+try {
+    FLIGHT_TRACKER_URL = require("./config").FLIGHT_TRACKER_URL;
+    console.log('Loaded config. FLIGHT_TRACKER_URL=' + FLIGHT_TRACKER_URL)
+} catch(e) {
+    console.log('No config found. Default FLIGHT_TRACKER_URL=' + FLIGHT_TRACKER_URL)
+}
+
 delete L.Icon.Default.prototype._getIconUrl;
 
 L.Icon.Default.mergeOptions({
@@ -57,7 +65,7 @@ export class RadarMap {
         this.signalsLayer = L.layerGroup();
         this.signalsLayer.addTo(this.map);
 
-        this.radarClient = new RadarClient('ws://localhost:8080/rsocket', new MapHandler(this.map));
+        this.radarClient = new RadarClient(FLIGHT_TRACKER_URL, new MapHandler(this.map));
         this.radarClient.connect(() => this.connectCallback());
 
         this.backpressureCtrl = new L.Control.BackpressureCtrl();

--- a/flight-tracker/src/main/java/io/spring/sample/flighttracker/config/JsonMetadataStrategiesCustomizer.java
+++ b/flight-tracker/src/main/java/io/spring/sample/flighttracker/config/JsonMetadataStrategiesCustomizer.java
@@ -26,7 +26,7 @@ public class JsonMetadataStrategiesCustomizer implements RSocketStrategiesCustom
 
 	@Override
 	public void customize(RSocketStrategies.Builder strategies) {
-		strategies.metadataExtractors(registry -> {
+		strategies.metadataExtractorRegistry(registry -> {
 			registry.metadataToExtract(METADATA_MIME_TYPE, METADATA_TYPE, (in, map) -> {
 				map.putAll(in);
 			});

--- a/flight-tracker/src/main/java/io/spring/sample/flighttracker/radars/RadarService.java
+++ b/flight-tracker/src/main/java/io/spring/sample/flighttracker/radars/RadarService.java
@@ -2,6 +2,7 @@ package io.spring.sample.flighttracker.radars;
 
 import java.util.List;
 
+import org.springframework.core.env.Environment;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -14,10 +15,12 @@ public class RadarService {
 
 	private final Mono<RSocketRequester> requesterMono;
 
-	public RadarService(RSocketRequester.Builder builder) {
+	public RadarService(RSocketRequester.Builder builder, Environment env) {
+		String host = env.getProperty("radar-service.host", "localhost");
+		int port = env.getProperty("radar-service.port", Integer.class, 9898);
 		this.requesterMono = builder
 				.dataMimeType(MediaType.APPLICATION_CBOR)
-				.connectTcp("localhost", 9898).retry(5).cache();
+				.connectTcp(host, port).retry(5).cache();
 	}
 
 	public Mono<AirportLocation> findRadar(String type, String code) {

--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -1,0 +1,7 @@
+cf:
+  route:
+    tcp:
+      domain: tcp.clearlake.cf-app.com
+      port: 1100
+    http:
+      domain: apps.clearlake.cf-app.com

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,13 @@
+---
+applications:
+  - name: radar-collector
+    routes:
+      - route: ((cf.route.tcp.domain)):((cf.route.tcp.port))
+    path: radar-collector/build/libs/radar-collector-0.0.1-SNAPSHOT.jar
+  - name: flight-tracker
+    routes:
+      - route: flight-tracker.((cf.route.http.domain))
+    path: flight-tracker/build/libs/flight-tracker-0.0.1-SNAPSHOT.jar
+    env:
+      RADAR-SERVICE_HOST: ((cf.route.tcp.domain))
+      RADAR-SERVICE_PORT: ((cf.route.tcp.port))

--- a/radar-collector/src/main/resources/application-cloud.properties
+++ b/radar-collector/src/main/resources/application-cloud.properties
@@ -1,0 +1,1 @@
+spring.rsocket.server.port=8080


### PR DESCRIPTION
Parameterized ws and tcp endpoints used by flight-client and flight-tracker.
Configured use of port 8080 for radar-controller under cloud profile.
Added manifest.yml and corresponding vars file for Cloud Foundry.
Updated README with instructions for deployment to Cloud Foundry.