### PR TITLE
Radar-collector filters by id or type when loading airports

### DIFF
--- a/flight-tracker/src/main/java/io/spring/sample/flighttracker/config/JsonMetadataStrategiesCustomizer.java
+++ b/flight-tracker/src/main/java/io/spring/sample/flighttracker/config/JsonMetadataStrategiesCustomizer.java
@@ -26,7 +26,7 @@ public class JsonMetadataStrategiesCustomizer implements RSocketStrategiesCustom
 
 	@Override
 	public void customize(RSocketStrategies.Builder strategies) {
-		strategies.metadataExtractors(registry -> {
+		strategies.metadataExtractorRegistry(registry -> {
 			registry.metadataToExtract(METADATA_MIME_TYPE, METADATA_TYPE, (in, map) -> {
 				map.putAll(in);
 			});

--- a/radar-collector/src/main/resources/application-civilian.properties
+++ b/radar-collector/src/main/resources/application-civilian.properties
@@ -1,0 +1,1 @@
+airports.filter.type=CIVILIAN

--- a/radar-collector/src/main/resources/application-military1.properties
+++ b/radar-collector/src/main/resources/application-military1.properties
@@ -1,0 +1,2 @@
+spring.rsocket.server.port=9897
+airports.filter.id=MIL-FR942

--- a/radar-collector/src/main/resources/application-military2.properties
+++ b/radar-collector/src/main/resources/application-military2.properties
@@ -1,0 +1,2 @@
+spring.rsocket.server.port=9896
+airports.filter.id=MIL-HLR


### PR DESCRIPTION
Added support for Radar-collector to filter by id or type when loading airports.
If  filter id or type are not set, all airports are loaded.
Including properties files for 3 profiles (civilian, military1, and military2) that will load different subsets of airports and listen on different tcp ports.
This is the first step towards an architecture where a gateway between flight-tracker and radar-collector would enable radar-collector to be decomposed into multiple services providing different subsets of airports, but I think it's simpler and cleaner to request a merge of smaller self-standing pieces individually as the work progresses.
